### PR TITLE
export actual range function from the module

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ range.js is a Node library approximation of Python's `range()` function.
 
 ```
 $ node
-> var range = require("range").range;
+> var range = require("range");
 > range(0, 20);
 [ 0,
   1,

--- a/lib/range.js
+++ b/lib/range.js
@@ -4,7 +4,7 @@
 //
 // Example:
 //
-// > var range = require("range").range;
+// > var range = require("range");
 // > range(0, 10);
 // [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
 
@@ -25,4 +25,5 @@ function range(a, b, step) {
   return r;
 }
 
-exports.range = range;
+module.exports = range;
+module.exports.range = range;

--- a/test/test.js
+++ b/test/test.js
@@ -20,4 +20,7 @@ describe("range", function() {
       assert(cmp.eq(range.range(3, 0, -2), [3, 1]), "regression: if step is not divisible by abs(start - stop) we get an infinite loop (negative step now)");
     });
   });
+  it("Should export the range() function, and also range.range() as a property", function() {
+    assert.strictEqual(range, range.range);
+  })
 });


### PR DESCRIPTION
This pull request makes the module export range() as a function directly. This is a common pattern in modules that only export a function, or whose functionality revolves around a single function.